### PR TITLE
Add Python wrapper for BarcodeAPI

### DIFF
--- a/barcodeapi_py/README.md
+++ b/barcodeapi_py/README.md
@@ -1,0 +1,55 @@
+# barcodeAPI-py
+
+`barcodeAPI-py` is a lightweight Python wrapper for the [BarcodeAPI.org](https://barcodeapi.org) REST service. It provides convenient helpers for generating and decoding barcodes and for accessing additional API endpoints such as bulk generation or type information.
+
+## Installation
+
+This library is not published to PyPI. Copy the `barcodeapi_py` directory into your project or install it directly from the repository.
+
+The only dependency is [`requests`](https://requests.readthedocs.io/), which is included with most Python distributions. Install it with:
+
+```bash
+pip install requests
+```
+
+## Usage
+
+```python
+from barcodeapi_py import BarcodeAPI
+
+api = BarcodeAPI()
+
+# Generate a barcode and save it to a file
+resp = api.generate("Hello World", code_type="qr", params={"height": 200})
+with open("hello.png", "wb") as fh:
+    fh.write(resp.content)
+
+# Decode a barcode image
+result = api.decode("hello.png")
+print(result["text"], result["format"])
+
+# Bulk generation from a CSV file
+zip_bytes = api.bulk_generate("requests.csv")
+with open("barcodes.zip", "wb") as fh:
+    fh.write(zip_bytes)
+
+# Inspect supported types
+types = api.get_types()
+print("Supported types:", [t["name"] for t in types])
+```
+
+## Available Methods
+
+| Method | Description |
+| --- | --- |
+| `generate(data, code_type="auto", params=None, headers=None)` | Generate a barcode image. Returns a `requests.Response` object containing image bytes and metadata headers. |
+| `decode(image)` | Decode a barcode from an image. Returns JSON with `text` and `format` fields. |
+| `bulk_generate(csv)` | Generate many barcodes at once from a CSV file. Returns ZIP archive bytes. |
+| `get_info()` | Retrieve server information such as uptime and version. |
+| `get_types()` | List all supported barcode types. |
+| `get_type(type_name)` | Fetch details for a single barcode type. |
+| `get_limiter()` | Return rate‑limit information for the current client. |
+| `get_session()` / `delete_session()` | Inspect or delete the current session. |
+| `create_share(requests_list)` / `get_share(key)` | Create or fetch a share that groups multiple barcode requests. |
+
+For full API documentation please see [barcodeapi.org/api.html](https://barcodeapi.org/api.html).

--- a/barcodeapi_py/__init__.py
+++ b/barcodeapi_py/__init__.py
@@ -1,0 +1,5 @@
+"""Python client for BarcodeAPI."""
+
+from .client import BarcodeAPI
+
+__all__ = ["BarcodeAPI"]

--- a/barcodeapi_py/client.py
+++ b/barcodeapi_py/client.py
@@ -1,0 +1,194 @@
+"""Simple Python wrapper around the BarcodeAPI.org REST interface."""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from typing import Iterable, Optional, Union
+from urllib.parse import quote
+
+try:  # pragma: no cover - used only when requests is unavailable
+    import requests
+except ModuleNotFoundError:  # pragma: no cover
+    class _DummySession:  # minimal stub used for environments without requests
+        def get(self, *args, **kwargs):  # pragma: no cover
+            raise ModuleNotFoundError("requests library is required")
+
+        def post(self, *args, **kwargs):  # pragma: no cover
+            raise ModuleNotFoundError("requests library is required")
+
+        def delete(self, *args, **kwargs):  # pragma: no cover
+            raise ModuleNotFoundError("requests library is required")
+
+    class requests:  # type: ignore
+        Session = _DummySession
+
+
+class BarcodeAPI:
+    """Client for the BarcodeAPI REST endpoints.
+
+    Parameters
+    ----------
+    base_url: str
+        Base URL of the BarcodeAPI server. Defaults to ``https://barcodeapi.org``.
+    session: requests.Session, optional
+        Optional :class:`requests.Session` instance to use for requests.
+    """
+
+    def __init__(self, base_url: str = "https://barcodeapi.org", session: Optional[requests.Session] = None):
+        self.base_url = base_url.rstrip("/")
+        self.session = session or requests.Session()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _encode_data(self, data: Union[str, int]) -> str:
+        return quote(str(data), safe="")
+
+    def _read_file(self, file: Union[str, bytes, os.PathLike, io.BufferedIOBase]) -> bytes:
+        if isinstance(file, (str, os.PathLike, Path)):
+            with open(file, "rb") as fh:
+                return fh.read()
+        if isinstance(file, bytes):
+            return file
+        return file.read()
+
+    # ------------------------------------------------------------------
+    # Public API methods
+    def generate(
+        self,
+        data: Union[str, int],
+        code_type: str = "auto",
+        params: Optional[dict] = None,
+        headers: Optional[dict] = None,
+    ) -> requests.Response:
+        """Generate a barcode for the provided data.
+
+        Parameters
+        ----------
+        data: str or int
+            The data to encode in the barcode.
+        code_type: str
+            Barcode format to generate, ``"auto"`` by default.
+        params: dict, optional
+            Additional query parameters for barcode customization.
+        headers: dict, optional
+            Additional headers to send with the request.
+
+        Returns
+        -------
+        requests.Response
+            The response object. ``response.content`` contains the barcode
+            image bytes. Response headers include barcode metadata.
+        """
+
+        url = f"{self.base_url}/api/{code_type}/{self._encode_data(data)}"
+        resp = self.session.get(url, params=params, headers=headers, stream=True)
+        resp.raise_for_status()
+        return resp
+
+    def decode(self, image: Union[str, bytes, os.PathLike, io.BufferedIOBase]) -> dict:
+        """Decode a barcode image.
+
+        Parameters
+        ----------
+        image: path-like, bytes or file-like object
+            Image containing a barcode. Accepted formats are path strings,
+            ``bytes`` objects, or file-like objects opened in binary mode.
+
+        Returns
+        -------
+        dict
+            JSON payload returned by the server.
+        """
+
+        data = self._read_file(image)
+        files = {"image": ("image.png", data)}
+        resp = self.session.post(f"{self.base_url}/decode", files=files)
+        resp.raise_for_status()
+        return resp.json()
+
+    def bulk_generate(self, csv: Union[str, bytes, os.PathLike, io.BufferedIOBase]) -> bytes:
+        """Generate many barcodes using the bulk API.
+
+        The server expects a CSV file whose rows describe the barcodes to
+        generate. The response is a ZIP archive containing the generated
+        barcodes.
+
+        Parameters
+        ----------
+        csv: path-like, bytes or file-like object
+            CSV file describing the barcodes to generate.
+
+        Returns
+        -------
+        bytes
+            Contents of the returned ZIP archive.
+        """
+
+        data = self._read_file(csv)
+        files = {"csvFile": ("bulk.csv", data)}
+        resp = self.session.post(f"{self.base_url}/bulk", files=files)
+        resp.raise_for_status()
+        return resp.content
+
+    def get_info(self) -> dict:
+        """Fetch server information."""
+        resp = self.session.get(f"{self.base_url}/info")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_types(self) -> list:
+        """Return a list of all supported barcode types."""
+        resp = self.session.get(f"{self.base_url}/types")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_type(self, type_name: str) -> dict:
+        """Return details for a single barcode type."""
+        resp = self.session.get(f"{self.base_url}/type", params={"type": type_name})
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_limiter(self) -> dict:
+        """Return rate limit information for the current client."""
+        resp = self.session.get(f"{self.base_url}/limiter")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_session(self) -> dict:
+        """Return session details if the request includes a valid session."""
+        resp = self.session.get(f"{self.base_url}/session")
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_session(self) -> bool:
+        """Delete the current session."""
+        resp = self.session.delete(f"{self.base_url}/session")
+        resp.raise_for_status()
+        return True
+
+    def create_share(self, requests_list: Iterable[str]) -> str:
+        """Create a share containing multiple barcode requests.
+
+        Parameters
+        ----------
+        requests_list: iterable of str
+            Each item should be a string representing a request URI
+            (e.g. ``"/api/qr/hello"``).
+
+        Returns
+        -------
+        str
+            The share key returned by the server.
+        """
+
+        resp = self.session.post(f"{self.base_url}/share", json=list(requests_list))
+        resp.raise_for_status()
+        return resp.text.strip()
+
+    def get_share(self, key: str) -> dict:
+        """Retrieve a previously created share."""
+        resp = self.session.get(f"{self.base_url}/share", params={"key": key})
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,53 @@
+import types
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from barcodeapi_py.client import BarcodeAPI
+
+
+class DummyResponse:
+    def __init__(self, *, json_data=None, content=b"", headers=None, status_code=200, text=""):
+        self._json = json_data
+        self.content = content
+        self.headers = headers or {}
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        if not (200 <= self.status_code < 300):
+            raise RuntimeError("HTTP error")
+
+    def json(self):
+        return self._json
+
+
+def test_generate_builds_correct_url():
+    captured = {}
+
+    def fake_get(url, *, params=None, headers=None, stream=None):
+        captured["url"] = url
+        return DummyResponse(content=b"img")
+
+    client = BarcodeAPI(base_url="https://example.com")
+    client.session.get = fake_get  # type: ignore[assignment]
+    client.generate("abc 123")
+    assert captured["url"] == "https://example.com/api/auto/abc%20123"
+
+
+def test_decode_posts_image():
+    captured = {}
+
+    def fake_post(url, *, files=None):
+        captured["url"] = url
+        captured["files"] = files
+        return DummyResponse(json_data={"code": 200, "text": "123", "format": "QR"})
+
+    client = BarcodeAPI(base_url="https://example.com")
+    client.session.post = fake_post  # type: ignore[assignment]
+    result = client.decode(b"123")
+    assert result["text"] == "123"
+    assert captured["url"] == "https://example.com/decode"
+    assert "image" in captured["files"]


### PR DESCRIPTION
## Summary
- add `barcodeAPI-py` package providing a Python client for BarcodeAPI endpoints
- document installation and usage examples for the new client
- include lightweight tests for core URL generation and image upload handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4c8130c3c8328b736b079d69fece0