### PR TITLE
Add Node.js wrapper for BarcodeAPI

### DIFF
--- a/barcodeapi_js/README.md
+++ b/barcodeapi_js/README.md
@@ -1,0 +1,53 @@
+# barcodeAPI-js
+
+`barcodeAPI-js` is a minimal Node.js client for the [BarcodeAPI.org](https://barcodeapi.org) REST service. It mirrors the features of the Python wrapper and exposes a simple class for generating and decoding barcodes or querying service metadata.
+
+## Installation
+
+This package is not published to npm. Copy the `barcodeapi_js` directory into your project or install directly from the repository.
+
+## Usage
+
+```javascript
+const { BarcodeAPI } = require('./barcodeapi_js');
+
+const api = new BarcodeAPI({ token: 'YOUR_API_TOKEN' }); // token optional
+
+// Generate a barcode and save to disk
+(async () => {
+  const resp = await api.generate('Hello World', 'qr', { params: { height: 200 } });
+  const fs = require('node:fs');
+  const buffer = Buffer.from(await resp.arrayBuffer());
+  fs.writeFileSync('hello.png', buffer);
+
+  // Decode a barcode image
+  const result = await api.decode('hello.png');
+  console.log(result.text, result.format);
+})();
+```
+
+### API Tokens
+
+Pass a token when constructing the client or update it later:
+
+```javascript
+const api = new BarcodeAPI({ token: 'my-token' });
+api.setToken('new-token'); // clear with null
+```
+
+## Available Methods
+
+| Method | Description |
+| --- | --- |
+| `generate(data, codeType = 'auto', options)` | Generate a barcode image. Returns a `Response` object containing image bytes and metadata. |
+| `decode(image)` | Decode a barcode from an image. Returns JSON with `text` and `format`. |
+| `bulkGenerate(csv)` | Generate many barcodes at once from a CSV file. Returns ZIP archive bytes. |
+| `getInfo()` | Retrieve server information such as uptime and version. |
+| `getTypes()` | List all supported barcode types. |
+| `getType(name)` | Fetch details for a single barcode type. |
+| `getLimiter()` | Return rate‑limit information for the current client. |
+| `getSession()` / `deleteSession()` | Inspect or delete the current session. |
+| `createShare(list)` / `getShare(key)` | Create or fetch a share that groups multiple barcode requests. |
+| `setToken(token)` | Set or clear the API token used for requests. |
+
+For complete API details see [barcodeapi.org/api.html](https://barcodeapi.org/api.html).

--- a/barcodeapi_js/index.js
+++ b/barcodeapi_js/index.js
@@ -1,0 +1,159 @@
+const { readFile } = require('node:fs/promises');
+const { URL } = require('node:url');
+
+class BarcodeAPI {
+  constructor({ baseUrl = 'https://barcodeapi.org', token } = {}) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    this.headers = {};
+    if (token) {
+      this.setToken(token);
+    } else {
+      this.token = null;
+    }
+  }
+
+  setToken(token) {
+    this.token = token || null;
+    if (this.token) {
+      this.headers['Authorization'] = `Token=${this.token}`;
+    } else {
+      delete this.headers['Authorization'];
+    }
+  }
+
+  _encodeData(data) {
+    return encodeURIComponent(String(data));
+  }
+
+  async _toBlob(file) {
+    if (file instanceof Blob) {
+      return file;
+    }
+    if (Buffer.isBuffer(file)) {
+      return new Blob([file]);
+    }
+    if (typeof file === 'string') {
+      const data = await readFile(file);
+      return new Blob([data]);
+    }
+    if (file && typeof file.arrayBuffer === 'function') {
+      const data = await file.arrayBuffer();
+      return new Blob([data]);
+    }
+    throw new TypeError('Unsupported file type');
+  }
+
+  async generate(data, codeType = 'auto', { params = {}, headers = {} } = {}) {
+    const url = new URL(`${this.baseUrl}/api/${codeType}/${this._encodeData(data)}`);
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+    const resp = await fetch(url, { headers: { ...this.headers, ...headers } });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp;
+  }
+
+  async decode(image) {
+    const blob = await this._toBlob(image);
+    const form = new FormData();
+    form.append('image', blob, 'image.png');
+    const resp = await fetch(`${this.baseUrl}/decode`, {
+      method: 'POST',
+      headers: this.headers,
+      body: form,
+    });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+
+  async bulkGenerate(csv) {
+    const blob = await this._toBlob(csv);
+    const form = new FormData();
+    form.append('csvFile', blob, 'bulk.csv');
+    const resp = await fetch(`${this.baseUrl}/bulk`, {
+      method: 'POST',
+      headers: this.headers,
+      body: form,
+    });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return Buffer.from(await resp.arrayBuffer());
+  }
+
+  async getInfo() {
+    const resp = await fetch(`${this.baseUrl}/info`, { headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+
+  async getTypes() {
+    const resp = await fetch(`${this.baseUrl}/types`, { headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+
+  async getType(typeName) {
+    const url = new URL(`${this.baseUrl}/type`);
+    url.searchParams.set('type', typeName);
+    const resp = await fetch(url, { headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+
+  async getLimiter() {
+    const resp = await fetch(`${this.baseUrl}/limiter`, { headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+
+  async getSession() {
+    const resp = await fetch(`${this.baseUrl}/session`, { headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+
+  async deleteSession() {
+    const resp = await fetch(`${this.baseUrl}/session`, { method: 'DELETE', headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return true;
+  }
+
+  async createShare(requestsList) {
+    const resp = await fetch(`${this.baseUrl}/share`, {
+      method: 'POST',
+      headers: { ...this.headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(Array.from(requestsList)),
+    });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.text();
+  }
+
+  async getShare(key) {
+    const url = new URL(`${this.baseUrl}/share`);
+    url.searchParams.set('key', key);
+    const resp = await fetch(url, { headers: this.headers });
+    if (!resp.ok) {
+      throw new Error('HTTP error');
+    }
+    return resp.json();
+  }
+}
+
+module.exports = { BarcodeAPI };

--- a/barcodeapi_py/README.md
+++ b/barcodeapi_py/README.md
@@ -1,0 +1,68 @@
+# barcodeAPI-py
+
+`barcodeAPI-py` is a lightweight Python wrapper for the [BarcodeAPI.org](https://barcodeapi.org) REST service. It provides convenient helpers for generating and decoding barcodes and for accessing additional API endpoints such as bulk generation or type information.
+
+## Installation
+
+This library is not published to PyPI. Copy the `barcodeapi_py` directory into your project or install it directly from the repository.
+
+The only dependency is [`requests`](https://requests.readthedocs.io/), which is included with most Python distributions. Install it with:
+
+```bash
+pip install requests
+```
+
+## Usage
+
+```python
+from barcodeapi_py import BarcodeAPI
+
+api = BarcodeAPI(token="YOUR_API_TOKEN")  # token is optional
+
+# Generate a barcode and save it to a file
+resp = api.generate("Hello World", code_type="qr", params={"height": 200})
+with open("hello.png", "wb") as fh:
+    fh.write(resp.content)
+
+# Decode a barcode image
+result = api.decode("hello.png")
+print(result["text"], result["format"])
+
+# Bulk generation from a CSV file
+zip_bytes = api.bulk_generate("requests.csv")
+with open("barcodes.zip", "wb") as fh:
+    fh.write(zip_bytes)
+
+# Inspect supported types
+types = api.get_types()
+print("Supported types:", [t["name"] for t in types])
+```
+
+### API Tokens
+
+If you have an API token, pass it when creating the client or set it later:
+
+```python
+api = BarcodeAPI(token="my-token")
+api.set_token("new-token")  # update or clear with None
+```
+
+The token is sent using the ``Authorization`` header and is used for
+authenticating requests and tracking rate limits.
+
+## Available Methods
+
+| Method | Description |
+| --- | --- |
+| `generate(data, code_type="auto", params=None, headers=None)` | Generate a barcode image. Returns a `requests.Response` object containing image bytes and metadata headers. |
+| `decode(image)` | Decode a barcode from an image. Returns JSON with `text` and `format` fields. |
+| `bulk_generate(csv)` | Generate many barcodes at once from a CSV file. Returns ZIP archive bytes. |
+| `get_info()` | Retrieve server information such as uptime and version. |
+| `get_types()` | List all supported barcode types. |
+| `get_type(type_name)` | Fetch details for a single barcode type. |
+| `get_limiter()` | Return rate‑limit information for the current client. |
+| `get_session()` / `delete_session()` | Inspect or delete the current session. |
+| `create_share(requests_list)` / `get_share(key)` | Create or fetch a share that groups multiple barcode requests. |
+| `set_token(token)` | Set or clear the API token used for requests. |
+
+For full API documentation please see [barcodeapi.org/api.html](https://barcodeapi.org/api.html).

--- a/barcodeapi_py/__init__.py
+++ b/barcodeapi_py/__init__.py
@@ -1,0 +1,5 @@
+"""Python client for BarcodeAPI."""
+
+from .client import BarcodeAPI
+
+__all__ = ["BarcodeAPI"]

--- a/barcodeapi_py/client.py
+++ b/barcodeapi_py/client.py
@@ -1,0 +1,219 @@
+"""Simple Python wrapper around the BarcodeAPI.org REST interface."""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from typing import Iterable, Optional, Union
+from urllib.parse import quote
+
+try:  # pragma: no cover - used only when requests is unavailable
+    import requests
+except ModuleNotFoundError:  # pragma: no cover
+    class _DummySession:  # minimal stub used for environments without requests
+        def __init__(self):  # pragma: no cover - simple container for headers
+            self.headers = {}
+
+        def get(self, *args, **kwargs):  # pragma: no cover
+            raise ModuleNotFoundError("requests library is required")
+
+        def post(self, *args, **kwargs):  # pragma: no cover
+            raise ModuleNotFoundError("requests library is required")
+
+        def delete(self, *args, **kwargs):  # pragma: no cover
+            raise ModuleNotFoundError("requests library is required")
+
+    class requests:  # type: ignore
+        Session = _DummySession
+
+
+class BarcodeAPI:
+    """Client for the BarcodeAPI REST endpoints.
+
+    Parameters
+    ----------
+    base_url: str
+        Base URL of the BarcodeAPI server. Defaults to ``https://barcodeapi.org``.
+    session: requests.Session, optional
+        Optional :class:`requests.Session` instance to use for requests.
+    token: str, optional
+        API token used to authenticate requests. When provided, the token is
+        passed using the ``Authorization`` header.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://barcodeapi.org",
+        session: Optional[requests.Session] = None,
+        token: Optional[str] = None,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.session = session or requests.Session()
+        self.token: Optional[str] = None
+        if token:
+            self.set_token(token)
+
+    def set_token(self, token: Optional[str]) -> None:
+        """Set or clear the API token used for requests.
+
+        Passing ``None`` removes any existing token.
+        """
+        self.token = token
+        if token:
+            self.session.headers["Authorization"] = f"Token={token}"
+        else:
+            self.session.headers.pop("Authorization", None)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _encode_data(self, data: Union[str, int]) -> str:
+        return quote(str(data), safe="")
+
+    def _read_file(self, file: Union[str, bytes, os.PathLike, io.BufferedIOBase]) -> bytes:
+        if isinstance(file, (str, os.PathLike, Path)):
+            with open(file, "rb") as fh:
+                return fh.read()
+        if isinstance(file, bytes):
+            return file
+        return file.read()
+
+    # ------------------------------------------------------------------
+    # Public API methods
+    def generate(
+        self,
+        data: Union[str, int],
+        code_type: str = "auto",
+        params: Optional[dict] = None,
+        headers: Optional[dict] = None,
+    ) -> requests.Response:
+        """Generate a barcode for the provided data.
+
+        Parameters
+        ----------
+        data: str or int
+            The data to encode in the barcode.
+        code_type: str
+            Barcode format to generate, ``"auto"`` by default.
+        params: dict, optional
+            Additional query parameters for barcode customization.
+        headers: dict, optional
+            Additional headers to send with the request.
+
+        Returns
+        -------
+        requests.Response
+            The response object. ``response.content`` contains the barcode
+            image bytes. Response headers include barcode metadata.
+        """
+
+        url = f"{self.base_url}/api/{code_type}/{self._encode_data(data)}"
+        resp = self.session.get(url, params=params, headers=headers, stream=True)
+        resp.raise_for_status()
+        return resp
+
+    def decode(self, image: Union[str, bytes, os.PathLike, io.BufferedIOBase]) -> dict:
+        """Decode a barcode image.
+
+        Parameters
+        ----------
+        image: path-like, bytes or file-like object
+            Image containing a barcode. Accepted formats are path strings,
+            ``bytes`` objects, or file-like objects opened in binary mode.
+
+        Returns
+        -------
+        dict
+            JSON payload returned by the server.
+        """
+
+        data = self._read_file(image)
+        files = {"image": ("image.png", data)}
+        resp = self.session.post(f"{self.base_url}/decode", files=files)
+        resp.raise_for_status()
+        return resp.json()
+
+    def bulk_generate(self, csv: Union[str, bytes, os.PathLike, io.BufferedIOBase]) -> bytes:
+        """Generate many barcodes using the bulk API.
+
+        The server expects a CSV file whose rows describe the barcodes to
+        generate. The response is a ZIP archive containing the generated
+        barcodes.
+
+        Parameters
+        ----------
+        csv: path-like, bytes or file-like object
+            CSV file describing the barcodes to generate.
+
+        Returns
+        -------
+        bytes
+            Contents of the returned ZIP archive.
+        """
+
+        data = self._read_file(csv)
+        files = {"csvFile": ("bulk.csv", data)}
+        resp = self.session.post(f"{self.base_url}/bulk", files=files)
+        resp.raise_for_status()
+        return resp.content
+
+    def get_info(self) -> dict:
+        """Fetch server information."""
+        resp = self.session.get(f"{self.base_url}/info")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_types(self) -> list:
+        """Return a list of all supported barcode types."""
+        resp = self.session.get(f"{self.base_url}/types")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_type(self, type_name: str) -> dict:
+        """Return details for a single barcode type."""
+        resp = self.session.get(f"{self.base_url}/type", params={"type": type_name})
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_limiter(self) -> dict:
+        """Return rate limit information for the current client."""
+        resp = self.session.get(f"{self.base_url}/limiter")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_session(self) -> dict:
+        """Return session details if the request includes a valid session."""
+        resp = self.session.get(f"{self.base_url}/session")
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_session(self) -> bool:
+        """Delete the current session."""
+        resp = self.session.delete(f"{self.base_url}/session")
+        resp.raise_for_status()
+        return True
+
+    def create_share(self, requests_list: Iterable[str]) -> str:
+        """Create a share containing multiple barcode requests.
+
+        Parameters
+        ----------
+        requests_list: iterable of str
+            Each item should be a string representing a request URI
+            (e.g. ``"/api/qr/hello"``).
+
+        Returns
+        -------
+        str
+            The share key returned by the server.
+        """
+
+        resp = self.session.post(f"{self.base_url}/share", json=list(requests_list))
+        resp.raise_for_status()
+        return resp.text.strip()
+
+    def get_share(self, key: str) -> dict:
+        """Retrieve a previously created share."""
+        resp = self.session.get(f"{self.base_url}/share", params={"key": key})
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,62 @@
+import types
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from barcodeapi_py.client import BarcodeAPI
+
+
+class DummyResponse:
+    def __init__(self, *, json_data=None, content=b"", headers=None, status_code=200, text=""):
+        self._json = json_data
+        self.content = content
+        self.headers = headers or {}
+        self.status_code = status_code
+        self.text = text
+
+    def raise_for_status(self):
+        if not (200 <= self.status_code < 300):
+            raise RuntimeError("HTTP error")
+
+    def json(self):
+        return self._json
+
+
+def test_generate_builds_correct_url():
+    captured = {}
+
+    def fake_get(url, *, params=None, headers=None, stream=None):
+        captured["url"] = url
+        return DummyResponse(content=b"img")
+
+    client = BarcodeAPI(base_url="https://example.com")
+    client.session.get = fake_get  # type: ignore[assignment]
+    client.generate("abc 123")
+    assert captured["url"] == "https://example.com/api/auto/abc%20123"
+
+
+def test_decode_posts_image():
+    captured = {}
+
+    def fake_post(url, *, files=None):
+        captured["url"] = url
+        captured["files"] = files
+        return DummyResponse(json_data={"code": 200, "text": "123", "format": "QR"})
+
+    client = BarcodeAPI(base_url="https://example.com")
+    client.session.post = fake_post  # type: ignore[assignment]
+    result = client.decode(b"123")
+    assert result["text"] == "123"
+    assert captured["url"] == "https://example.com/decode"
+    assert "image" in captured["files"]
+
+
+def test_token_header_and_setter():
+    client = BarcodeAPI(base_url="https://example.com", token="abc")
+    assert client.session.headers["Authorization"] == "Token=abc"
+    client.set_token("xyz")
+    assert client.session.headers["Authorization"] == "Token=xyz"
+    client.set_token(None)
+    assert "Authorization" not in client.session.headers

--- a/tests/test_client_js.js
+++ b/tests/test_client_js.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { BarcodeAPI } = require('../barcodeapi_js');
+
+test('generate builds correct url', async () => {
+  const realFetch = global.fetch;
+  const captured = {};
+  global.fetch = async (url) => {
+    captured.url = url.toString();
+    return new Response('img');
+  };
+  const client = new BarcodeAPI({ baseUrl: 'https://example.com' });
+  await client.generate('abc 123');
+  assert.strictEqual(captured.url, 'https://example.com/api/auto/abc%20123');
+  global.fetch = realFetch;
+});
+
+test('decode posts image', async () => {
+  const realFetch = global.fetch;
+  const captured = {};
+  global.fetch = async (url, options) => {
+    captured.url = url;
+    captured.method = options.method;
+    captured.body = options.body;
+    return new Response(JSON.stringify({ code: 200, text: '123', format: 'QR' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  const client = new BarcodeAPI({ baseUrl: 'https://example.com' });
+  const result = await client.decode(Buffer.from('123'));
+  assert.strictEqual(result.text, '123');
+  assert.strictEqual(captured.url, 'https://example.com/decode');
+  assert.ok(captured.body instanceof FormData);
+  assert.ok(captured.body.get('image'));
+  global.fetch = realFetch;
+});
+
+test('token header and setter', () => {
+  const client = new BarcodeAPI({ baseUrl: 'https://example.com', token: 'abc' });
+  assert.strictEqual(client.headers['Authorization'], 'Token=abc');
+  client.setToken('xyz');
+  assert.strictEqual(client.headers['Authorization'], 'Token=xyz');
+  client.setToken(null);
+  assert.ok(!('Authorization' in client.headers));
+});


### PR DESCRIPTION
## Summary
- add `barcodeapi-js` package providing a Node.js client for BarcodeAPI endpoints
- document installation and usage examples for the new JavaScript client
- include lightweight tests for core URL generation, image upload handling, and token management

## Testing
- `node --test tests/test_client_js.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c8130c3c8328b736b079d69fece0