### PR TITLE
Ensure client endpoints use trailing slashes

### DIFF
--- a/barcodeapi_esp32/barcodeapi.cpp
+++ b/barcodeapi_esp32/barcodeapi.cpp
@@ -113,7 +113,7 @@ Response BarcodeAPI::decode(const std::string& image) {
     body << "\r\n--" << boundary << "--\r\n";
     Headers hdr = headers_;
     hdr["Content-Type"] = "multipart/form-data; boundary=" + boundary;
-    return request("POST", baseUrl_ + "/decode", hdr, body.str());
+    return request("POST", baseUrl_ + "/decode/", hdr, body.str());
 }
 
 Response BarcodeAPI::bulkGenerate(const std::string& csv) {
@@ -126,31 +126,31 @@ Response BarcodeAPI::bulkGenerate(const std::string& csv) {
     body << "\r\n--" << boundary << "--\r\n";
     Headers hdr = headers_;
     hdr["Content-Type"] = "multipart/form-data; boundary=" + boundary;
-    return request("POST", baseUrl_ + "/bulk", hdr, body.str());
+    return request("POST", baseUrl_ + "/bulk/", hdr, body.str());
 }
 
 Response BarcodeAPI::getInfo() {
-    return request("GET", baseUrl_ + "/info", headers_, "");
+    return request("GET", baseUrl_ + "/info/", headers_, "");
 }
 
 Response BarcodeAPI::getTypes() {
-    return request("GET", baseUrl_ + "/types", headers_, "");
+    return request("GET", baseUrl_ + "/types/", headers_, "");
 }
 
 Response BarcodeAPI::getType(const std::string& typeName) {
-    return request("GET", baseUrl_ + "/type?type=" + encode(typeName), headers_, "");
+    return request("GET", baseUrl_ + "/type/?type=" + encode(typeName), headers_, "");
 }
 
 Response BarcodeAPI::getLimiter() {
-    return request("GET", baseUrl_ + "/limiter", headers_, "");
+    return request("GET", baseUrl_ + "/limiter/", headers_, "");
 }
 
 Response BarcodeAPI::getSession() {
-    return request("GET", baseUrl_ + "/session", headers_, "");
+    return request("GET", baseUrl_ + "/session/", headers_, "");
 }
 
 Response BarcodeAPI::deleteSession() {
-    return request("DELETE", baseUrl_ + "/session", headers_, "");
+    return request("DELETE", baseUrl_ + "/session/", headers_, "");
 }
 
 Response BarcodeAPI::createShare(const std::vector<std::string>& requestsList) {
@@ -163,10 +163,10 @@ Response BarcodeAPI::createShare(const std::vector<std::string>& requestsList) {
     body << "]";
     Headers hdr = headers_;
     hdr["Content-Type"] = "application/json";
-    return request("POST", baseUrl_ + "/share", hdr, body.str());
+    return request("POST", baseUrl_ + "/share/", hdr, body.str());
 }
 
 Response BarcodeAPI::getShare(const std::string& key) {
-    return request("GET", baseUrl_ + "/share?key=" + encode(key), headers_, "");
+    return request("GET", baseUrl_ + "/share/?key=" + encode(key), headers_, "");
 }
 

--- a/barcodeapi_js/index.js
+++ b/barcodeapi_js/index.js
@@ -57,7 +57,7 @@ class BarcodeAPI {
     const blob = await this._toBlob(image);
     const form = new FormData();
     form.append('image', blob, 'image.png');
-    const resp = await fetch(`${this.baseUrl}/decode`, {
+    const resp = await fetch(`${this.baseUrl}/decode/`, {
       method: 'POST',
       headers: this.headers,
       body: form,
@@ -72,7 +72,7 @@ class BarcodeAPI {
     const blob = await this._toBlob(csv);
     const form = new FormData();
     form.append('csvFile', blob, 'bulk.csv');
-    const resp = await fetch(`${this.baseUrl}/bulk`, {
+    const resp = await fetch(`${this.baseUrl}/bulk/`, {
       method: 'POST',
       headers: this.headers,
       body: form,
@@ -84,7 +84,7 @@ class BarcodeAPI {
   }
 
   async getInfo() {
-    const resp = await fetch(`${this.baseUrl}/info`, { headers: this.headers });
+    const resp = await fetch(`${this.baseUrl}/info/`, { headers: this.headers });
     if (!resp.ok) {
       throw new Error('HTTP error');
     }
@@ -92,7 +92,7 @@ class BarcodeAPI {
   }
 
   async getTypes() {
-    const resp = await fetch(`${this.baseUrl}/types`, { headers: this.headers });
+    const resp = await fetch(`${this.baseUrl}/types/`, { headers: this.headers });
     if (!resp.ok) {
       throw new Error('HTTP error');
     }
@@ -100,7 +100,7 @@ class BarcodeAPI {
   }
 
   async getType(typeName) {
-    const url = new URL(`${this.baseUrl}/type`);
+    const url = new URL(`${this.baseUrl}/type/`);
     url.searchParams.set('type', typeName);
     const resp = await fetch(url, { headers: this.headers });
     if (!resp.ok) {
@@ -110,7 +110,7 @@ class BarcodeAPI {
   }
 
   async getLimiter() {
-    const resp = await fetch(`${this.baseUrl}/limiter`, { headers: this.headers });
+    const resp = await fetch(`${this.baseUrl}/limiter/`, { headers: this.headers });
     if (!resp.ok) {
       throw new Error('HTTP error');
     }
@@ -118,7 +118,7 @@ class BarcodeAPI {
   }
 
   async getSession() {
-    const resp = await fetch(`${this.baseUrl}/session`, { headers: this.headers });
+    const resp = await fetch(`${this.baseUrl}/session/`, { headers: this.headers });
     if (!resp.ok) {
       throw new Error('HTTP error');
     }
@@ -126,7 +126,7 @@ class BarcodeAPI {
   }
 
   async deleteSession() {
-    const resp = await fetch(`${this.baseUrl}/session`, { method: 'DELETE', headers: this.headers });
+    const resp = await fetch(`${this.baseUrl}/session/`, { method: 'DELETE', headers: this.headers });
     if (!resp.ok) {
       throw new Error('HTTP error');
     }
@@ -134,7 +134,7 @@ class BarcodeAPI {
   }
 
   async createShare(requestsList) {
-    const resp = await fetch(`${this.baseUrl}/share`, {
+    const resp = await fetch(`${this.baseUrl}/share/`, {
       method: 'POST',
       headers: { ...this.headers, 'Content-Type': 'application/json' },
       body: JSON.stringify(Array.from(requestsList)),
@@ -146,7 +146,7 @@ class BarcodeAPI {
   }
 
   async getShare(key) {
-    const url = new URL(`${this.baseUrl}/share`);
+    const url = new URL(`${this.baseUrl}/share/`);
     url.searchParams.set('key', key);
     const resp = await fetch(url, { headers: this.headers });
     if (!resp.ok) {

--- a/barcodeapi_py/client.py
+++ b/barcodeapi_py/client.py
@@ -129,7 +129,7 @@ class BarcodeAPI:
 
         data = self._read_file(image)
         files = {"image": ("image.png", data)}
-        resp = self.session.post(f"{self.base_url}/decode", files=files)
+        resp = self.session.post(f"{self.base_url}/decode/", files=files)
         resp.raise_for_status()
         return resp.json()
 
@@ -153,43 +153,43 @@ class BarcodeAPI:
 
         data = self._read_file(csv)
         files = {"csvFile": ("bulk.csv", data)}
-        resp = self.session.post(f"{self.base_url}/bulk", files=files)
+        resp = self.session.post(f"{self.base_url}/bulk/", files=files)
         resp.raise_for_status()
         return resp.content
 
     def get_info(self) -> dict:
         """Fetch server information."""
-        resp = self.session.get(f"{self.base_url}/info")
+        resp = self.session.get(f"{self.base_url}/info/")
         resp.raise_for_status()
         return resp.json()
 
     def get_types(self) -> list:
         """Return a list of all supported barcode types."""
-        resp = self.session.get(f"{self.base_url}/types")
+        resp = self.session.get(f"{self.base_url}/types/")
         resp.raise_for_status()
         return resp.json()
 
     def get_type(self, type_name: str) -> dict:
         """Return details for a single barcode type."""
-        resp = self.session.get(f"{self.base_url}/type", params={"type": type_name})
+        resp = self.session.get(f"{self.base_url}/type/", params={"type": type_name})
         resp.raise_for_status()
         return resp.json()
 
     def get_limiter(self) -> dict:
         """Return rate limit information for the current client."""
-        resp = self.session.get(f"{self.base_url}/limiter")
+        resp = self.session.get(f"{self.base_url}/limiter/")
         resp.raise_for_status()
         return resp.json()
 
     def get_session(self) -> dict:
         """Return session details if the request includes a valid session."""
-        resp = self.session.get(f"{self.base_url}/session")
+        resp = self.session.get(f"{self.base_url}/session/")
         resp.raise_for_status()
         return resp.json()
 
     def delete_session(self) -> bool:
         """Delete the current session."""
-        resp = self.session.delete(f"{self.base_url}/session")
+        resp = self.session.delete(f"{self.base_url}/session/")
         resp.raise_for_status()
         return True
 
@@ -208,12 +208,12 @@ class BarcodeAPI:
             The share key returned by the server.
         """
 
-        resp = self.session.post(f"{self.base_url}/share", json=list(requests_list))
+        resp = self.session.post(f"{self.base_url}/share/", json=list(requests_list))
         resp.raise_for_status()
         return resp.text.strip()
 
     def get_share(self, key: str) -> dict:
         """Retrieve a previously created share."""
-        resp = self.session.get(f"{self.base_url}/share", params={"key": key})
+        resp = self.session.get(f"{self.base_url}/share/", params={"key": key})
         resp.raise_for_status()
         return resp.json()

--- a/barcodeapi_rb/barcodeapi.rb
+++ b/barcodeapi_rb/barcodeapi.rb
@@ -33,7 +33,7 @@ class BarcodeAPI
     boundary = "----------#{rand(1_000_000)}"
     body = build_multipart({ 'image' => data }, boundary)
     headers = { 'Content-Type' => "multipart/form-data; boundary=#{boundary}" }
-    resp = request(:post, '/decode', headers: headers, body: body)
+    resp = request(:post, '/decode/', headers: headers, body: body)
     JSON.parse(resp.body)
   end
 
@@ -42,48 +42,48 @@ class BarcodeAPI
     boundary = "----------#{rand(1_000_000)}"
     body = build_multipart({ 'csvFile' => data }, boundary)
     headers = { 'Content-Type' => "multipart/form-data; boundary=#{boundary}" }
-    resp = request(:post, '/bulk', headers: headers, body: body)
+    resp = request(:post, '/bulk/', headers: headers, body: body)
     resp.body
   end
 
   def get_info
-    resp = request(:get, '/info')
+    resp = request(:get, '/info/')
     JSON.parse(resp.body)
   end
 
   def get_types
-    resp = request(:get, '/types')
+    resp = request(:get, '/types/')
     JSON.parse(resp.body)
   end
 
   def get_type(type_name)
-    resp = request(:get, '/type', params: { type: type_name })
+    resp = request(:get, '/type/', params: { type: type_name })
     JSON.parse(resp.body)
   end
 
   def get_limiter
-    resp = request(:get, '/limiter')
+    resp = request(:get, '/limiter/')
     JSON.parse(resp.body)
   end
 
   def get_session
-    resp = request(:get, '/session')
+    resp = request(:get, '/session/')
     JSON.parse(resp.body)
   end
 
   def delete_session
-    request(:delete, '/session')
+    request(:delete, '/session/')
     true
   end
 
   def create_share(requests_list)
     headers = { 'Content-Type' => 'application/json' }
-    resp = request(:post, '/share', headers: headers, body: requests_list.to_json)
+    resp = request(:post, '/share/', headers: headers, body: requests_list.to_json)
     resp.body.strip
   end
 
   def get_share(key)
-    resp = request(:get, '/share', params: { key: key })
+    resp = request(:get, '/share/', params: { key: key })
     JSON.parse(resp.body)
   end
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,7 +49,7 @@ def test_decode_posts_image():
     client.session.post = fake_post  # type: ignore[assignment]
     result = client.decode(b"123")
     assert result["text"] == "123"
-    assert captured["url"] == "https://example.com/decode"
+    assert captured["url"] == "https://example.com/decode/"
     assert "image" in captured["files"]
 
 

--- a/tests/test_client_cpp.cpp
+++ b/tests/test_client_cpp.cpp
@@ -23,7 +23,7 @@ int main() {
     BarcodeAPI client2("https://example.com", "", req2);
     auto resp = client2.decode("123");
     assert(cap2.method == "POST");
-    assert(cap2.url == "https://example.com/decode");
+    assert(cap2.url == "https://example.com/decode/");
     assert(cap2.headers.count("Content-Type"));
     assert(cap2.headers["Content-Type"].find("multipart/form-data") != std::string::npos);
     assert(cap2.body.find("123") != std::string::npos);

--- a/tests/test_client_js.js
+++ b/tests/test_client_js.js
@@ -30,7 +30,7 @@ test('decode posts image', async () => {
   const client = new BarcodeAPI({ baseUrl: 'https://example.com' });
   const result = await client.decode(Buffer.from('123'));
   assert.strictEqual(result.text, '123');
-  assert.strictEqual(captured.url, 'https://example.com/decode');
+  assert.strictEqual(captured.url, 'https://example.com/decode/');
   assert.ok(captured.body instanceof FormData);
   assert.ok(captured.body.get('image'));
   global.fetch = realFetch;

--- a/tests/test_client_rb.rb
+++ b/tests/test_client_rb.rb
@@ -27,7 +27,7 @@ class TestBarcodeAPI < Minitest::Test
     client = BarcodeAPI.new(base_url: 'https://example.com', requester: requester)
     result = client.decode('123')
     assert_equal :post, captured[:method]
-    assert_equal 'https://example.com/decode', captured[:url]
+    assert_equal 'https://example.com/decode/', captured[:url]
     assert_match(/image/, captured[:body])
     assert_equal '123', result['text']
   end


### PR DESCRIPTION
## Summary
- add trailing slashes to REST endpoint URLs in Python, JavaScript, Ruby, and ESP32 client libraries
- update tests to expect new endpoint paths with trailing slash

## Testing
- `pytest tests/test_client.py`
- `ruby tests/test_client_rb.rb`
- `node tests/test_client_js.js`
- `g++ -std=c++17 tests/test_client_cpp.cpp barcodeapi_esp32/barcodeapi.cpp -o tests/test_client_cpp && tests/test_client_cpp`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4957860832889d65080c42a83ef